### PR TITLE
fix: Remove hero caption pop-up animation

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -871,21 +871,7 @@ ul {
 
 /* Dark mode .carousel-caption style removed */
 
-/* Animation for carousel caption */
-@keyframes captionFadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.carousel-caption.caption-animate-in {
-    animation: captionFadeInUp 0.7s 0.3s ease-out forwards; /* 0.3s delay after slide fades in */
-}
+/* Animation for carousel caption - REMOVED */
 
 .hero-quote-btn {
     display: inline-block; /* Or block if it should take full width of caption */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -68,18 +68,17 @@ class Carousel {
     updateCarousel() {
         this.slides.forEach((slide, index) => {
             slide.classList.remove('active');
-            const caption = slide.querySelector('.carousel-caption');
-            if (caption) {
-                caption.classList.remove('caption-animate-in');
-            }
+            // const caption = slide.querySelector('.carousel-caption'); // No longer needed
+            // if (caption) { // No longer needed
+            //     caption.classList.remove('caption-animate-in'); // No longer needed
+            // } // No longer needed
 
             if (index === this.currentIndex) {
                 slide.classList.add('active');
-                // Re-trigger animation for the new active slide's caption
-                if (caption) {
-                    // Timeout to allow class removal to register before re-adding
-                    setTimeout(() => caption.classList.add('caption-animate-in'), 50);
-                }
+                // Animation logic for caption removed
+                // if (caption) { // No longer needed
+                    // setTimeout(() => caption.classList.add('caption-animate-in'), 50); // No longer needed
+                // } // No longer needed
             }
         });
 


### PR DESCRIPTION
Removes the dedicated pop-up animation for the hero carousel caption to resolve a double animation issue. The caption will now fade in/out smoothly with the main slide transition.

- Deleted @keyframes captionFadeInUp and .carousel-caption.caption-animate-in CSS rules.
- Removed JavaScript logic in Carousel.updateCarousel that triggered the separate caption animation.