### PR TITLE
fix: Adjust hero caption animation to be significantly slower

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1035,7 +1035,7 @@ ul {
 }
 
 .carousel-caption.caption-animate-in {
-    animation: captionFadeInUp 0.5s 0.1s ease-out forwards; /* Quicker: 0.5s duration, 0.1s delay */
+    animation: captionFadeInUp 1.2s 0.4s ease-out forwards; /* Slower: 1.2s duration, 0.4s delay */
 }
 
 .hero-quote-btn {


### PR DESCRIPTION
Corrects the hero carousel caption's pop-up animation timing. The animation duration is increased to 1.2s and delay to 0.4s to make the effect slower and less abrupt, as per user feedback.